### PR TITLE
Changed default algorithm to compute omega.

### DIFF
--- a/man/createClusterMST.Rd
+++ b/man/createClusterMST.Rd
@@ -70,8 +70,7 @@ All weights should be positive and sum to 1 for each row.}
 \item{outgroup}{A logical scalar indicating whether an outgroup should be inserted to split unrelated trajectories.
 Alternatively, a numeric scalar specifying the distance threshold to use for this splitting.}
 
-\item{outscale}{A numeric scalar specifying the scaling to apply to the median distance between centroids
-to define the threshold for outgroup splitting.
+\item{outscale}{A numeric scalar specifying the number of MADs above the median, used to define the threshold for outgroup splitting - see Details.
 Only used if \code{outgroup=TRUE}.}
 
 \item{endpoints}{A character vector of clusters that must be endpoints, i.e., nodes of degree 1 or lower in the MST.}
@@ -129,9 +128,9 @@ Large jumps in the MST between real clusters that are more distant than \eqn{\om
 allowing us to break up the MST into multiple subcomponents (i.e., a minimum spanning forest) by removing the outgroup.
 
 The default \eqn{\omega} value is computed by constructing the MST from the original distance matrix,
-computing the median edge length in that MST, and then scaling it by \code{outscale}.
-This adapts to the magnitude of the distances and the internal structure of the dataset
-while also providing some margin for variation across cluster pairs.
+computing the median edge length in that MST, and then adding it to the MAD of the edge lengths multiplied by \code{outscale}.
+This effectively identifies branches with large \dQuote{outlier} distances and breaks them to form separate graph components.
+In this manner, we adapt to the magnitude of the distances and the internal structure of the dataset while still allowing for some variation in the distances. 
 Alternatively, \code{outgroup} can be set to a numeric scalar in which case it is used directly as \eqn{\omega}.
 }
 


### PR DESCRIPTION
@kstreet13 

Currently, the OMEGA distance is defined as `outscale * median(mst.dist)`, where `mst.dist` is the vector of branch lengths along the MST. This seems to behave poorly at higher dimensions where all the distances are large and it's pretty hard to actually get clusters that are more than 3 times (the default `outscale`) greater than the median distance.

So, this PR switches to an outlier-based approach where the OMEGA threshold is defined as `outscale * mad(mst.dist) + median(mst.dist)`. This effectively "breaks" unusually long branches to form separate components, and should be more tolerant of large distances at high dimensions (where random noise serves as a baseline that shouldn't be multiplied anyway).

The change seems to work pretty well for the various examples in the OSCA book, which failed to form separate components when we switched **TSCAN** to use the new `createClusterMST()`. The difference was that I fixed the bug whereby the `outscale` was half of what it was meant to be, but in doing so, the threshold became too large to permit the formation of separate components.

Thoughts on how this might impact **slingshot** would be welcome. Though I don't think you've switched over yet anyway.